### PR TITLE
docs: add branch strategy and PR rules, update contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,13 @@
 
 Thank you for your interest in contributing to YUBI!
 
+## How to Contribute
+
+1. Fork this repository
+2. Create a feature branch (`git checkout -b feature/your-change`)
+3. Commit your changes
+4. Push to the branch and open a Pull Request
+
 ## Branch Strategy
 
 This repository uses the following branch strategy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,78 @@
-# Contributing
+# Contributing Guide
 
-Thank you for your interest in contributing to YUBI!
+## Branch Strategy
 
-## How to Contribute
+This repository uses the following branch strategy.
 
-1. Fork this repository
-2. Create a feature branch (`git checkout -b feature/your-change`)
-3. Commit your changes
-4. Push to the branch and open a Pull Request
+### `main`
 
-## Guidelines
+The `main` branch contains the latest stable version of the project.
 
-- CAD files should be provided in both STEP and STL formats
-- Update the relevant BOM (CSV) if parts are added or changed
-- Keep file names consistent with the existing naming convention
+All files in `main` should be in a state that can be reviewed, built, assembled, or released by external users.
 
-## Reporting Issues
+Direct pushes to `main` are not allowed.
+All changes must be submitted through pull requests.
 
-Please use [GitHub Issues](../../issues) to report bugs or suggest improvements.
+### `feature/*`
+
+Use `feature/*` branches for new features, design updates, or functional improvements.
+
+Examples:
+
+```text
+feature/gripper-redesign
+feature/add-sensor-mount
+feature/update-cad-structure
+```
+
+### `fix/*`
+
+Use `fix/*` branches for correcting mistakes, defects, or inconsistencies.
+
+Examples:
+
+```text
+fix/bom-screw-length
+fix/cad-hole-position
+fix/assembly-step-error
+```
+
+### `docs/*`
+
+Use `docs/*` branches for documentation updates.
+
+Examples:
+
+```text
+docs/update-readme
+docs/add-assembly-guide
+docs/add-contribution-guide
+```
+
+## Releases
+
+Releases are managed using Git tags.
+
+Examples:
+
+```text
+v0.1.0
+v1.0.0
+v1.0.1
+```
+
+A release tag should represent a reproducible set of hardware design files, including CAD files, BOM, assembly instructions, and related documentation.
+
+## Pull Request Rule
+
+All changes must be submitted through pull requests.
+
+Before merging, please check that:
+
+- The purpose of the change is clear
+- CAD, BOM, and documentation are consistent
+- No internal or confidential information is included
+- The change follows the branch naming rule
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing Guide
 
+Thank you for your interest in contributing to YUBI!
+
 ## Branch Strategy
 
 This repository uses the following branch strategy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,16 @@ Before merging, please check that:
 - No internal or confidential information is included
 - The change follows the branch naming rule
 
+## Guidelines
+
+- CAD files should be provided in both STEP and STL formats
+- Update the relevant BOM (CSV) if parts are added or changed
+- Keep file names consistent with the existing naming convention
+
+## Reporting Issues
+
+Please use [GitHub Issues](../../issues) to report bugs or suggest improvements.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under [CERN-OHL-W v2](LICENSE).

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@
 | Yuki Noguchi | Frontier Research Center, Toyota Motor Corporation | Concept Design |
 | Makoto Sugiura| AI Robot Association | Data Collection Rig Design |
 | Takehiko Ohkawa| AI Robot Association | Data Collection Concept Design |
+| Masayoshi Tsuchinaga | Frontier Research Center, Toyota Motor Corporation | Core Maintainer |
+| Yusuke Mizuoka | Frontier Research Center, Toyota Motor Corporation | Maintainer |
 
 ## License
 


### PR DESCRIPTION
## Purpose
Establish the minimum contribution rules required for an OSH repository,
and reflect the new maintainers in the Contributors list.

## Changes
- **CONTRIBUTING.md** — full rewrite
  - Document the branch strategy (`main` / `feature/*` / `fix/*` / `docs/*`)
  - Add release management via Git tags (e.g. `v0.1.0`)
  - Add a pre-merge checklist (clear purpose / CAD-BOM-docs consistency / no confidential info / branch naming rule)
- **README.md** — add two entries to the Contributors table
  - Masayoshi Tsuchinaga — Core Maintainer
  - Yusuke Mizuoka — Maintainer

## Checklist
- [x] The purpose of the change is clear
- [x] CAD, BOM, and documentation are consistent (docs-only change)
- [x] No internal or confidential information is included
- [x] The change follows the branch naming rule (`docs/update-docs`)