### PR TITLE
docs: add project page link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <img src="media/teaser_v3.png" alt="YUBI Overview" width="600">
 </p>
 
+🌐 **Project page:** [yubi.airoa.io](https://yubi.airoa.io/)
+
 **YUBI** is a finger-driven dexterous manipulation system developed by Frontier Research Center, Toyota Motor Corporation.
 
 ## Part Overview


### PR DESCRIPTION
## Purpose
Add a link to the YUBI project page so readers can reach it directly from the README,
matching the style used in yubi-sw.

## Changes
- **README.md** — add `🌐 Project page: yubi.airoa.io` near the top, just above the project description

## Checklist
- [x] The purpose of the change is clear
- [x] CAD, BOM, and documentation are consistent (docs-only change)
- [x] No internal or confidential information is included
- [x] The change follows the branch naming rule (`docs/add-project-page-link`)