### PR TITLE
docs: add citation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@
 | Masayoshi Tsuchinaga | Frontier Research Center, Toyota Motor Corporation | Core Maintainer |
 | Yusuke Mizuoka | Frontier Research Center, Toyota Motor Corporation | Maintainer |
 
+## Citation
+
+If you use YUBI in your research, please cite:
+
+```bibtex
+@misc{ohkawa2026yubi,
+      title={{YUBI}: Yielding Universal Bidigital Interface for Bimanual Dexterous Manipulation at Scale},
+      author={Takehiko Ohkawa and Jumpei Arima and Yuki Noguchi and Masatoshi Tateno and Makoto Sugiura and Takuya Okubo and Kengo Ikeuchi and Yuma Shin and Hiroki Nishizawa and Naoaki Kanazawa and Yuki Wakayama and Daiki Fukunaga and Koshi Makihara and Tomohiro Motoda and Floris Erich and Yukiyasu Domae and Tatsuya Matsushima and Yohishiro Okumatsu and Kei Ota},
+      year={2026},
+      eprint={2606.10244},
+      archivePrefix={arXiv},
+      primaryClass={cs.RO},
+      url={https://arxiv.org/abs/2606.10244},
+}
+```
+
 ## License
 
 This project is licensed under the [CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W v2)](LICENSE).


### PR DESCRIPTION
## Purpose
Add a citation section to the README so users can reference the YUBI paper in their research publications.

## Changes
README.md — add `## Citation` section with BibTeX entry for the arXiv paper (2606.10244), inserted between the Contributors table and the License section

## Checklist
- [x] The purpose of the change is clear
- [x] CAD, BOM, and documentation are consistent (docs-only change)
- [x] No internal or confidential information is included
- [x] The change follows the branch naming rule (`docs/add-citation`)