### PR TITLE
docs: add Kazutomo Misao to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@
 
 | Name | Affiliation | Role |
 |------|-------------|------|
-| Yoshihiro Okumatsu | Frontier Research Center, Toyota Motor Corporation | Project Lead |
+| Kazutomo Misao | Frontier Research Center, Toyota Motor Corporation | Project Lead |
+| Yoshihiro Okumatsu | Frontier Research Center, Toyota Motor Corporation | Project Sub-Lead |
 | Daiki Fukunaga | Frontier Research Center, Toyota Motor Corporation | Mechanical Design |
 | Jumpei Arima | Frontier Research Center, Toyota Motor Corporation | Concept Design |
 | Yuki Noguchi | Frontier Research Center, Toyota Motor Corporation | Concept Design |


### PR DESCRIPTION
## Purpose

Add Kazutomo Misao to the README contributors list.

## Changes

README.md — add Kazutomo Misao as Project Lead in the Contributors table

## Checklist

- [x] The purpose of the change is clear
- [x] CAD, BOM, and documentation are consistent (docs-only change)
- [x] No internal or confidential information is included
- [x] The change follows the branch naming rule (docs/add-contributor-kazutomo-mis