### PR TITLE
docs: add commercial use guidelines

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,211 @@
+# Commercial Use Guidelines
+
+This project is released as Open Source Hardware under the
+[CERN Open Hardware Licence Version 2 - Weakly Reciprocal
+(CERN-OHL-W v2)](LICENSE).
+
+You are free to manufacture, assemble, and sell products based on this
+design. However, compliance with the license is required when distributing
+Covered Source or products based on it.
+
+This document is a practical summary, not legal advice or a replacement for
+the license. If this document and the official license terms differ, the
+official license terms control.
+
+## 1. Summary
+
+You are allowed to:
+
+- manufacture products based on this design;
+- assemble and sell hardware commercially; and
+- integrate this design into larger systems.
+
+When distributing Covered Source or products based on it, you must comply
+with the conditions described below and with CERN-OHL-W v2.
+
+## 2. Mandatory Requirements (License Compliance)
+
+### 2.1 License Notice and Attribution
+
+When distributing Covered Source or products based on it, retain the
+applicable notices and provide:
+
+- a reference to the CERN-OHL-W v2 license;
+- a reference to the original YUBI project; and
+- the applicable Source Location.
+
+Example:
+
+```text
+This product is based on the YUBI open-source hardware project.
+Licensed under CERN-OHL-W v2.
+Source: https://github.com/Toyota/yubi-hw
+```
+
+### 2.2 Access to Source
+
+When distributing a product based on YUBI, you must either:
+
+- provide each recipient with a copy of the Complete Source; or
+- notify each recipient where the Complete Source can be obtained.
+
+For an unmodified YUBI product, the original Source Location is:
+
+<https://github.com/Toyota/yubi-hw>
+
+A Source Location should be a location that you reasonably believe will
+remain easily accessible for at least three years, as defined by
+CERN-OHL-W v2.
+
+### 2.3 Modifications (If Applicable)
+
+You may modify the design. If you distribute modified Covered Source or a
+product based on it:
+
+- you must make the modified Covered Source available as required by the
+  license; and
+- the modified Covered Source must be licensed under CERN-OHL-W v2 or
+  another version permitted by the license.
+
+### 2.4 Change Documentation
+
+When distributing modified Covered Source, you must clearly state:
+
+- who made the changes;
+- the date of the changes; and
+- a brief description of what was changed.
+
+Example:
+
+```text
+Modified by [Company or Individual Name] on [YYYY-MM-DD].
+Changes:
+- Modified the finger joint geometry
+- Reinforced structural components
+
+Modified Source:
+https://example.com/path/to/source
+```
+
+### 2.5 Copyright Notice
+
+The design files and documentation are copyrighted. You must:
+
+- preserve applicable existing copyright notices; and
+- clearly indicate the original copyright holder.
+
+Example:
+
+```text
+Copyright 2026 Toyota Motor Corporation
+```
+
+Copyright ownership does not prevent use or commercial sale. Rights to use,
+make, and sell products are granted subject to CERN-OHL-W v2.
+
+### 2.6 Trademark Usage and Branding
+
+The Toyota name, Toyota logos, and associated marks are protected. This
+project and CERN-OHL-W v2 do not grant trademark rights.
+
+You must NOT:
+
+- represent your product as an official Toyota product;
+- use Toyota logos in products or marketing without authorization; or
+- imply endorsement, certification, sponsorship, or involvement by Toyota
+  Motor Corporation.
+
+If you refer to Toyota Motor Corporation or YUBI in product documentation
+or marketing, clearly distinguish your product from the original project.
+We recommend including a disclaimer such as:
+
+```text
+This product is based on the YUBI open-source hardware project.
+Toyota Motor Corporation does not endorse or certify this product.
+```
+
+Acceptable factual reference:
+
+```text
+Based on the YUBI open-source hardware project
+```
+
+Unacceptable claims include:
+
+```text
+Toyota official product
+Toyota-certified hardware
+```
+
+## 3. What You Are Allowed to Do
+
+Subject to CERN-OHL-W v2 and any other applicable rights, you may:
+
+- sell assembled hardware products;
+- set your own price;
+- combine YUBI with proprietary components or systems; and
+- use, make, offer to sell, sell, import, and otherwise transfer products
+  based on the Covered Source.
+
+No royalties are required by Toyota Motor Corporation for rights granted
+under CERN-OHL-W v2.
+
+## 4. What You Are Not Required to Do
+
+CERN-OHL-W v2 does not necessarily require you to:
+
+- open source your entire product;
+- open source unrelated components or External Material.
+
+Modified Covered Source remains subject to the license requirements.
+Available Components and External Material are treated according to the
+definitions and conditions in CERN-OHL-W v2.
+
+## 5. Safety and Liability
+
+The original authors provide the Covered Source and products "as is",
+without warranties, as described in CERN-OHL-W v2.
+
+If you manufacture, distribute, or sell a product based on YUBI, you are
+responsible for:
+
+- product quality;
+- product safety;
+- testing and quality assurance;
+- compliance with applicable laws, regulations, and standards; and
+- claims, warranties, and support offered for your product.
+
+Example:
+
+```text
+This product is provided by [Company Name].
+The original authors are not responsible for its safety or liability.
+```
+
+## 6. Recommended Best Practices
+
+Although not required, we encourage:
+
+- contributing improvements back to the project;
+- publishing modified designs publicly; and
+- providing clear documentation to users.
+
+## 7. Contact for Commercial Use
+
+If you plan to manufacture or sell products based on YUBI, we kindly ask
+that you contact us:
+
+<yubi-contact@mail.toyota.co.jp>
+
+This contact request is voluntary and is not an additional condition of
+CERN-OHL-W v2. Contacting us does not constitute approval, certification,
+endorsement, or a separate commercial license.
+
+## 8. Final Note
+
+These guidelines are intended to help companies correctly apply
+CERN-OHL-W v2 when using YUBI commercially.
+
+For the official license terms, refer to:
+
+<https://cern-ohl.web.cern.ch/>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@
 
 - [yubi-sw](https://github.com/airoa-org/yubi-sw) — Software (control, teleoperation)
 
+## Commercial Use
+
+Commercial manufacturing and sale of products based on YUBI are permitted
+subject to CERN-OHL-W v2. See the [Commercial Use Guidelines](COMMERCIAL.md)
+for practical guidance.
+
 ## Contributors
 
 | Name | Affiliation | Role |


### PR DESCRIPTION
## Purpose

Add commercial use guidelines for products based on YUBI.

## Changes

- Add `COMMERCIAL.md` covering CERN-OHL-W v2 compliance, modified designs, trademarks, safety, and liability
- Add the voluntary commercial-use contact address
- Add a link to the guidelines from `README.md`
- Standardize the project name as `YUBI`

## Checklist

- [x] The purpose of the change is clear
- [x] CAD, BOM, and documentation are consistent (docs-only change)
- [x] No internal or confidential information is included
- [x] The change follows the branch naming rule (`docs/add-commercial-use-guidelines`)