### PR TITLE
Fix LICENSE text so GitHub can detect CERN-OHL-W-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,87 +1,289 @@
 Copyright 2026 Toyota Motor Corporation
 
-This Source describes Open Hardware and is licensed under the CERN-OHL-W v2.
+CERN Open Hardware Licence Version 2 - Weakly Reciprocal
 
-You may redistribute and modify this documentation and make products using it
-under the terms of the CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W v2).
-
-This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
-INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A PARTICULAR PURPOSE.
-Please see the CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W v2) for applicable conditions.
-
-Source location: https://github.com/Toyota/yubi-hw
-
-As per CERN-OHL-W v2 section 4, should you produce hardware based on this documentation,
-you must maintain the Source available and provide it to recipients of the hardware.
-
-
---------------------------------------------------------------------------------
-CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W v2)
---------------------------------------------------------------------------------
 
 Preamble
 
-This CERN Open Hardware Licence version 2 - Weakly Reciprocal (CERN-OHL-W v2) is
-designed for the licensing of hardware designs. The licensed material is a
-hardware design, and the licence covers the documentation.
+CERN has developed this licence to promote collaboration among hardware
+designers and to provide a legal tool which supports the freedom to use,
+study, modify, share and distribute hardware designs and products based on
+those designs. Version 2 of the CERN Open Hardware Licence comes in three
+variants: CERN-OHL-P (permissive); and two reciprocal licences: this licence,
+CERN-OHL-W (weakly reciprocal) and CERN-OHL-S (strongly reciprocal).
 
-The CERN-OHL-W is a licence which ensures that modifications to the licensed
-material are shared under the same licence, while allowing combination with
-other works under different terms.
+The CERN-OHL-W is copyright CERN 2020. Anyone is welcome to use it, in
+unmodified form only.
 
-Definitions
+Use of this Licence does not imply any endorsement by CERN of any Licensor or
+their designs nor does it imply any involvement by CERN in their development.
 
-"Licence" means this CERN-OHL-W.
 
-"Source" means information that is sufficient to make, test, modify and distribute
-a product based on the licensed material.
+1 Definitions
 
-"Product" means any device made using the Source.
+  1.1 'Licence' means this CERN-OHL-W.
 
-"Licensee" means any person exercising rights under this Licence.
+  1.2 'Compatible Licence' means
 
-"Licensor" means the person granting rights under this Licence.
+       a) any earlier version of the CERN Open Hardware licence, or
 
-Grant of rights
+       b) any version of the CERN-OHL-S or the CERN-OHL-W, or
 
-The Licensor grants the Licensee the right to use, reproduce, modify, distribute,
-and make Products using the Source.
+       c) any licence which permits You to treat the Source to which it
+          applies as licensed under CERN-OHL-S or CERN-OHL-W provided that on
+          Conveyance of any such Source, or any associated Product You treat
+          the Source in question as being licensed under CERN-OHL-S or
+          CERN-OHL-W as appropriate.
 
-Conditions
+  1.3 'Source' means information such as design materials or digital code
+      which can be applied to Make or test a Product or to prepare a Product
+      for use, Conveyance or sale, regardless of its medium or how it is
+      expressed. It may include Notices.
 
-1. If you distribute the Source or modified Source, you must do so under the
-   terms of this Licence.
+  1.4 'Covered Source' means Source that is explicitly made available under
+      this Licence.
 
-2. If you make modifications, you must make the modified Source available.
+  1.5 'Product' means any device, component, work or physical object, whether
+      in finished or intermediate form, arising from the use, application or
+      processing of Covered Source.
 
-3. You may combine the Source with other materials under different licences,
-   provided that the Source itself remains under CERN-OHL-W.
+  1.6 'Make' means to create or configure something, whether by manufacture,
+      assembly, compiling, loading or applying Covered Source or another
+      Product or otherwise.
 
-4. If you distribute a Product, you must provide access to the Source used to
-   create it, or indicate where it can be obtained.
+  1.7 'Available Component' means any part, sub-assembly, library or code
+      which:
 
-Disclaimer
+       a) is licensed to You as Complete Source under a Compatible Licence; or
 
-The Source is provided "as is", without any warranty of any kind, express or
-implied, including but not limited to warranties of merchantability, fitness
-for a particular purpose, and non-infringement.
+       b) is available, at the time a Product or the Source containing it is
+          first Conveyed, to You and any other prospective licensees
 
-Limitation of liability
+           i) with sufficient rights and information (including any
+              configuration and programming files and information about its
+              characteristics and interfaces) to enable it either to be Made
+              itself, or to be sourced and used to Make the Product; or
+          ii) as part of the normal distribution of a tool used to design or
+              Make the Product.
 
-In no event shall the Licensor be liable for any damages arising from the use
-of the Source or Products.
+  1.8 'External Material' means anything (including Source) which:
 
-Termination
+       a) is only combined with Covered Source in such a way that it
+          interfaces with the Covered Source using a documented interface
+          which is described in the Covered Source; and
 
-This Licence terminates automatically if you fail to comply with its terms.
+       b) is not a derivative of or contains Covered Source, or, if it is, it
+          is solely to the extent necessary to facilitate such interfacing.
 
-Reinstatement
+  1.9 'Complete Source' means the set of all Source necessary to Make a
+      Product, in the preferred form for making modifications, including
+      necessary installation and interfacing information both for the Product,
+      and for any included Available Components.  If the format is
+      proprietary, it must also be made available in a format (if the
+      proprietary tool can create it) which is viewable with a tool available
+      to potential licensees and licensed under a licence approved by the Free
+      Software Foundation or the Open Source Initiative. Complete Source need
+      not include the Source of any Available Component, provided that You
+      include in the Complete Source sufficient information to enable a
+      recipient to Make or source and use the Available Component to Make the
+      Product.
 
-You may reinstate your rights if you correct the violation within a reasonable time.
+ 1.10 'Source Location' means a location where a Licensor has placed Covered
+      Source, and which that Licensor reasonably believes will remain easily
+      accessible for at least three years for anyone to obtain a digital copy.
 
-General
+ 1.11 'Notice' means copyright, acknowledgement and trademark notices, Source
+      Location references, modification notices (subsection 3.3(b)) and all
+      notices that refer to this Licence and to the disclaimer of warranties
+      that are included in the Covered Source.
 
-This Licence represents the complete agreement concerning the subject matter.
+ 1.12 'Licensee' or 'You' means any person exercising rights under this
+      Licence.
 
-For full details, see:
-https://cern-ohl.web.cern.ch/
+ 1.13 'Licensor' means a natural or legal person who creates or modifies
+      Covered Source. A person may be a Licensee and a Licensor at the same
+      time.
+
+ 1.14 'Convey' means to communicate to the public or distribute.
+
+
+2 Applicability
+
+  2.1 This Licence governs the use, copying, modification, Conveying of
+      Covered Source and Products, and the Making of Products. By exercising
+      any right granted under this Licence, You irrevocably accept these terms
+      and conditions.
+
+  2.2 This Licence is granted by the Licensor directly to You, and shall apply
+      worldwide and without limitation in time.
+
+  2.3 You shall not attempt to restrict by contract or otherwise the rights
+      granted under this Licence to other Licensees.
+
+  2.4 This Licence is not intended to restrict fair use, fair dealing, or any
+      other similar right.
+
+
+3 Copying, Modifying and Conveying Covered Source
+
+  3.1 You may copy and Convey verbatim copies of Covered Source, in any
+      medium, provided You retain all Notices.
+
+  3.2 You may modify Covered Source, other than Notices, provided that You
+      irrevocably undertake to make that modified Covered Source available
+      from a Source Location should You Convey a Product in circumstances
+      where the recipient does not otherwise receive a copy of the modified
+      Covered Source. In each case subsection 3.3 shall apply.
+
+      You may only delete Notices if they are no longer applicable to the
+      corresponding Covered Source as modified by You and You may add
+      additional Notices applicable to Your modifications.
+
+  3.3 You may Convey modified Covered Source (with the effect that You shall
+      also become a Licensor) provided that You:
+
+       a) retain Notices as required in subsection 3.2;
+
+       b) add a Notice to the modified Covered Source stating that You have
+          modified it, with the date and brief description of how You have
+          modified it;
+
+       c) add a Source Location Notice for the modified Covered Source if You
+          Convey in circumstances where the recipient does not otherwise
+          receive a copy of the modified Covered Source; and
+
+       d) license the modified Covered Source under the terms and conditions
+          of this Licence (or, as set out in subsection 8.3, a later version,
+          if permitted by the licence of the original Covered Source). Such
+          modified Covered Source must be licensed as a whole, but excluding
+          Available Components contained in it or External Material to which
+          it is interfaced, which remain licensed under their own applicable
+          licences.
+
+
+4 Making and Conveying Products
+
+  4.1 You may Make Products, and/or Convey them, provided that You either
+      provide each recipient with a copy of the Complete Source or ensure that
+      each recipient is notified of the Source Location of the Complete
+      Source. That Complete Source includes Covered Source and You must
+      accordingly satisfy Your obligations set out in subsection 3.3. If
+      specified in a Notice, the Product must visibly and securely display the
+      Source Location on it or its packaging or documentation in the manner
+      specified in that Notice.
+
+  4.2 Where You Convey a Product which incorporates External Material, the
+      Complete Source for that Product which You are required to provide under
+      subsection 4.1 need not include any Source for the External Material.
+
+  4.3 You may license Products under terms of Your choice, provided that such
+      terms do not restrict or attempt to restrict any recipients' rights
+      under this Licence to the Covered Source.
+
+
+5 Research and Development
+
+You may Convey Covered Source, modified Covered Source or Products to a legal
+entity carrying out development, testing or quality assurance work on Your
+behalf provided that the work is performed on terms which prevent the entity
+from both using the Source or Products for its own internal purposes and
+Conveying the Source or Products or any modifications to them to any person
+other than You. Any modifications made by the entity shall be deemed to be
+made by You pursuant to subsection 3.2.
+
+
+6 DISCLAIMER AND LIABILITY
+
+  6.1 DISCLAIMER OF WARRANTY -- The Covered Source and any Products are
+      provided 'as is' and any express or implied warranties, including, but
+      not limited to, implied warranties of merchantability, of satisfactory
+      quality, non-infringement of third party rights, and fitness for a
+      particular purpose or use are disclaimed in respect of any Source or
+      Product to the maximum extent permitted by law. The Licensor makes no
+      representation that any Source or Product does not or will not infringe
+      any patent, copyright, trade secret or other proprietary right. The
+      entire risk as to the use, quality, and performance of any Source or
+      Product shall be with You and not the Licensor. This disclaimer of
+      warranty is an essential part of this Licence and a condition for the
+      grant of any rights granted under this Licence.
+
+  6.2 EXCLUSION AND LIMITATION OF LIABILITY -- The Licensor shall, to the
+      maximum extent permitted by law, have no liability for direct, indirect,
+      special, incidental, consequential, exemplary, punitive or other damages
+      of any character including, without limitation, procurement of
+      substitute goods or services, loss of use, data or profits, or business
+      interruption, however caused and on any theory of contract, warranty,
+      tort (including negligence), product liability or otherwise, arising in
+      any way in relation to the Covered Source, modified Covered Source
+      and/or the Making or Conveyance of a Product, even if advised of the
+      possibility of such damages, and You shall hold the Licensor(s) free and
+      harmless from any liability, costs, damages, fees and expenses,
+      including claims by third parties, in relation to such use.
+
+
+7 Patents
+
+  7.1 Subject to the terms and conditions of this Licence, each Licensor
+      hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+      royalty-free, irrevocable (except as stated in subsections 7.2 and 8.4)
+      patent licence to Make, have Made, use, offer to sell, sell, import, and
+      otherwise transfer the Covered Source and Products, where such licence
+      applies only to those patent claims licensable by such Licensor that are
+      necessarily infringed by exercising rights under the Covered Source as
+      Conveyed by that Licensor.
+
+  7.2 If You institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Covered
+      Source or a Product constitutes direct or contributory patent
+      infringement, or You seek any declaration that a patent licensed to You
+      under this Licence is invalid or unenforceable then any rights granted
+      to You under this Licence shall terminate as of the date such process is
+      initiated.
+
+
+8 General
+
+  8.1 If any provisions of this Licence are or subsequently become invalid or
+      unenforceable for any reason, the remaining provisions shall remain
+      effective.
+
+  8.2 You shall not use any of the name (including acronyms and
+      abbreviations), image, or logo by which the Licensor or CERN is known,
+      except where needed to comply with section 3, or where the use is
+      otherwise allowed by law. Any such permitted use shall be factual and
+      shall not be made so as to suggest any kind of endorsement or
+      implication of involvement by the Licensor or its personnel.
+
+  8.3 CERN may publish updated versions and variants of this Licence which it
+      considers to be in the spirit of this version, but may differ in detail
+      to address new problems or concerns. New versions will be published with
+      a unique version number and a variant identifier specifying the variant.
+      If the Licensor has specified that a given variant applies to the
+      Covered Source without specifying a version, You may treat that Covered
+      Source as being released under any version of the CERN-OHL with that
+      variant. If no variant is specified, the Covered Source shall be treated
+      as being released under CERN-OHL-S. The Licensor may also specify that
+      the Covered Source is subject to a specific version of the CERN-OHL or
+      any later version in which case You may apply this or any later version
+      of CERN-OHL with the same variant identifier published by CERN.
+
+      You may treat Covered Source licensed under CERN-OHL-W as licensed under
+      CERN-OHL-S if and only if all Available Components referenced in the
+      Covered Source comply with the corresponding definition of Available
+      Component for CERN-OHL-S.
+
+  8.4 This Licence shall terminate with immediate effect if You fail to comply
+      with any of its terms and conditions.
+
+  8.5 However, if You cease all breaches of this Licence, then Your Licence
+      from any Licensor is reinstated unless such Licensor has terminated this
+      Licence by giving You, while You remain in breach, a notice specifying
+      the breach and requiring You to cure it within 30 days, and You have
+      failed to come into compliance in all material respects by the end of
+      the 30 day period. Should You repeat the breach after receipt of a cure
+      notice and subsequent reinstatement, this Licence will terminate
+      immediately and permanently. Section 6 shall continue to apply after any
+      termination.
+
+  8.6 This Licence shall not be enforceable except by a Licensor acting as
+       such, and third party beneficiary rights are specifically excluded.

--- a/README.md
+++ b/README.md
@@ -104,12 +104,3 @@ If you use YUBI in your research, please cite:
 This project is licensed under the [CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W v2)](LICENSE).
 
 Copyright 2026 Toyota Motor Corporation
-
-This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
-INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A PARTICULAR PURPOSE.
-Please see the CERN-OHL-W v2 for applicable conditions.
-
-Source location: https://github.com/Toyota/yubi-hw
-
-As per CERN-OHL-W v2 section 4, should you produce hardware based on this documentation,
-you must maintain the Source available and provide it to recipients of the hardware.

--- a/README.md
+++ b/README.md
@@ -104,3 +104,12 @@ If you use YUBI in your research, please cite:
 This project is licensed under the [CERN Open Hardware Licence Version 2 - Weakly Reciprocal (CERN-OHL-W v2)](LICENSE).
 
 Copyright 2026 Toyota Motor Corporation
+
+This documentation is distributed WITHOUT ANY EXPRESS OR IMPLIED WARRANTY,
+INCLUDING OF MERCHANTABILITY, SATISFACTORY QUALITY AND FITNESS FOR A PARTICULAR PURPOSE.
+Please see the CERN-OHL-W v2 for applicable conditions.
+
+Source location: https://github.com/Toyota/yubi-hw
+
+As per CERN-OHL-W v2 section 4, should you produce hardware based on this documentation,
+you must maintain the Source available and provide it to recipients of the hardware.


### PR DESCRIPTION
## Summary
- Replace the LICENSE file's paraphrased license text with the verbatim CERN-OHL-W v2 text so GitHub's license detector (Licensee) can recognize it as `CERN-OHL-W-2.0` instead of showing "View license" / `Other`.
- Move the project-specific notices (source location, section 4 hardware note) from LICENSE into the License section of README.md.

## Test plan
- [ ] After merge, confirm `gh api repos/Toyota/yubi-hw --jq '.license'` reports `cern-ohl-w-2.0` (may take a short time for GitHub to re-scan).
- [ ] Confirm the repo's About sidebar shows "CERN-OHL-W-2.0 license" instead of "View license".